### PR TITLE
add owner attribute on process struct:

### DIFF
--- a/contracts/common.sol
+++ b/contracts/common.sol
@@ -14,7 +14,7 @@ interface IProcessStore {
     function getProcessId(address entityAddress, uint256 processCountIndex, uint32 namespaceId, uint32 chainId) external pure returns (bytes32);
     function get(bytes32 processId) external view returns (
         uint8[3] memory mode_envelopeType_censusOrigin,
-        address entityAddress,
+        address[2] memory entityAddress_owner,
         string[3] memory metadata_censusRoot_censusUri,
         uint32[2] memory startBlock_blockCount,
         Status status,

--- a/lib/contract-definitions.ts
+++ b/lib/contract-definitions.ts
@@ -176,7 +176,7 @@ export type IProcessCreateEvmParamsTuple = [
 ]
 export type IProcessStateTuple = [
     number[], // mode_envelopeType_censusOrigin
-    string,   // entityAddress
+    string[],   // entityAddress_owner
     string[], // metadata_censusRoot_censusUri
     number[], // startBlock_blockCount
     IProcessStatus, // status

--- a/lib/data-wrappers.ts
+++ b/lib/data-wrappers.ts
@@ -193,6 +193,7 @@ export class ProcessContractParameters {
     censusOrigin: ProcessCensusOrigin;
     /** Entity or Token Address */
     entityAddress?: string;
+    owner?: string;
     metadata: string;
     censusRoot: string;
     censusUri?: string;
@@ -300,8 +301,15 @@ export class ProcessContractParameters {
         result.envelopeType = new ProcessEnvelopeType(params[0][1])
         result.censusOrigin = new ProcessCensusOrigin(params[0][2] as IProcessCensusOrigin)
 
+        /*
         if (typeof params[1] != "string") throw new Error("Invalid entityAddress")
         result.entityAddress = params[1]
+        */
+        if (!Array.isArray(params[1]) || params[1].length != 2 || params[1].some((item) => typeof item != "string"))
+            throw new Error("Invalid parameters entity_owner")
+
+        result.entityAddress = params[1][0]
+        result.owner = params[1][1]
 
         if (!Array.isArray(params[2]) || params[2].length != 3 || params[2].some((item) => typeof item != "string"))
             throw new Error("Invalid parameters metadata_censusRoot_censusUri list")

--- a/test/builders/process.ts
+++ b/test/builders/process.ts
@@ -129,7 +129,6 @@ export default class ProcessBuilder {
                     maxVoteOverwrites: this.maxVoteOverwrites,
                     maxTotalCost: this.maxTotalCost,
                     costExponent: this.costExponent,
-                    tokenAddress: this.tokenAddress,
                     evmBlockHeight: this.evmBlockHeight,
                     paramsSignature: this.paramsSignature
                 }).toContractParamsEvm(extraParams)
@@ -257,11 +256,6 @@ export default class ProcessBuilder {
 
     withEvmBlockHeight(evmBlockHeight: number) {
         this.evmBlockHeight = evmBlockHeight
-        return this
-    }
-
-    withTokenAddress(tokenAddress: string) {
-        this.tokenAddress = tokenAddress
         return this
     }
 

--- a/test/wrappers/process-contract-params.ts
+++ b/test/wrappers/process-contract-params.ts
@@ -82,7 +82,7 @@ describe("Process contract parameter wrapper", () => {
         it("should unwrap the 'get' response values", () => {
             const json1 = ProcessContractParameters.fromContract([
                 [1, 2, 3],
-                "0x3",
+                ["0x3", "0x0"],
                 ["0x4", "0x5", "0x6"],
                 [7, 8],
                 0,
@@ -95,6 +95,7 @@ describe("Process contract parameter wrapper", () => {
             expect(json1.envelopeType.value).to.eq(2)
             expect(json1.censusOrigin.value).to.eq(3)
             expect(json1.entityAddress).to.eq("0x3")
+            expect(json1.owner).to.eq("0x0")
             expect(json1.metadata).to.eq("0x4")
             expect(json1.censusRoot).to.eq("0x5")
             expect(json1.censusUri).to.eq("0x6")
@@ -112,7 +113,7 @@ describe("Process contract parameter wrapper", () => {
     
             const json2 = ProcessContractParameters.fromContract([
                 [10, 3, 2],
-                "0x30",
+                ["0x30", "0x40"],
                 ["0x40", "0x50", "0x60"],
                 [70, 80],
                 1,
@@ -125,6 +126,7 @@ describe("Process contract parameter wrapper", () => {
             expect(json2.envelopeType.value).to.eq(3)
             expect(json2.censusOrigin.value).to.eq(2)
             expect(json2.entityAddress).to.eq("0x30")
+            expect(json2.owner).to.eq("0x40")
             expect(json2.metadata).to.eq("0x40")
             expect(json2.censusRoot).to.eq("0x50")
             expect(json2.censusUri).to.eq("0x60")
@@ -220,7 +222,7 @@ describe("Process contract parameter wrapper", () => {
         it("should unwrap the 'get' response values", () => {
             const json1 = ProcessContractParameters.fromContract([
                 [1, 2, 11],
-                "0x3",
+                ["0x3", "0x0"],
                 ["0x4", "0x5", ""],
                 [7, 8],
                 0,
@@ -234,6 +236,7 @@ describe("Process contract parameter wrapper", () => {
             expect(json1.censusOrigin.value).to.eq(11)
             expect(json1.censusUri).to.eq("")
             expect(json1.entityAddress).to.eq("0x3")
+            expect(json1.owner).to.eq("0x0")
             expect(json1.metadata).to.eq("0x4")
             expect(json1.censusRoot).to.eq("0x5")
             expect(json1.startBlock).to.eq(7)
@@ -250,7 +253,7 @@ describe("Process contract parameter wrapper", () => {
     
             const json2 = ProcessContractParameters.fromContract([
                 [10, 3, 12],
-                "0x30",
+                ["0x30", "0x40"],
                 ["0x40", "0x50", ""],
                 [70, 80],
                 1,
@@ -263,6 +266,7 @@ describe("Process contract parameter wrapper", () => {
             expect(json2.envelopeType.value).to.eq(3)
             expect(json2.censusOrigin.value).to.eq(12)
             expect(json2.entityAddress).to.eq("0x30")
+            expect(json2.owner).to.eq("0x40")
             expect(json2.metadata).to.eq("0x40")
             expect(json2.censusRoot).to.eq("0x50")
             expect(json2.censusUri).to.eq("")


### PR DESCRIPTION
For EVM processes the entityId is a token
contract address. If the process wants to
have the capacity for incrementing a process
question index and given the process having
the required properties enabled to do so, there is
no way to call the incrementQuestionIndex method
for the process because the token contract does not
always have the capacity of calling the method.
Adding the owner attribute enables to increment
the question index by the creator of a process.
This also enables the possibility of changing
some EVM process atritibutes on the future
by just having to check if the msg.sender
is the creator of a process.